### PR TITLE
[GSS00005] Encapsulate !

### DIFF
--- a/app/src/main/java/com/anelcc/guessexample/screen/game/GameFragment.kt
+++ b/app/src/main/java/com/anelcc/guessexample/screen/game/GameFragment.kt
@@ -47,8 +47,6 @@ public class GameFragment : Fragment() {
             updateWordText()
         }
 
-        viewModel.score.value = -10000
-
         /** Setting up LiveData observation relationship **/
         viewModel.score.observe(this, Observer { newScore ->
             binding.scoreText.text = newScore.toString()

--- a/app/src/main/java/com/anelcc/guessexample/screen/game/GameFragment.kt
+++ b/app/src/main/java/com/anelcc/guessexample/screen/game/GameFragment.kt
@@ -47,6 +47,8 @@ public class GameFragment : Fragment() {
             updateWordText()
         }
 
+        viewModel.score.value = -10000
+
         /** Setting up LiveData observation relationship **/
         viewModel.score.observe(this, Observer { newScore ->
             binding.scoreText.text = newScore.toString()
@@ -67,7 +69,6 @@ public class GameFragment : Fragment() {
     /** Methods for updating the UI **/
 
     private fun updateWordText() {
-        binding.wordText.text = viewModel.word
-
+        binding.wordText.text = viewModel.word.value
     }
 }

--- a/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
+++ b/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
@@ -17,6 +17,8 @@ class GameViewModel : ViewModel(){
     private val _score = MutableLiveData<Int>()
     //external
     val score: LiveData<Int>
+        get() = _score
+
 
     // The list of words - the front of the list is the next word to guess
     private lateinit var wordList: MutableList<String>

--- a/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
+++ b/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
@@ -1,6 +1,7 @@
 package com.anelcc.guessexample.screen.game
 
 import android.util.Log
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 //The ViewModel is a stable place to store the data to display in the associated UI controller.
@@ -12,7 +13,10 @@ class GameViewModel : ViewModel(){
     var word = MutableLiveData<String>()
 
     // The current score
-    var score = MutableLiveData<Int>()
+    // internal
+    private val _score = MutableLiveData<Int>()
+    //external
+    val score: LiveData<Int>
 
     // The list of words - the front of the list is the next word to guess
     private lateinit var wordList: MutableList<String>

--- a/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
+++ b/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
@@ -9,10 +9,8 @@ import androidx.lifecycle.ViewModel
 //The ViewModel never contains references to activities, fragments, or views.
 class GameViewModel : ViewModel(){
 
-    // The current word
     var word = MutableLiveData<String>()
 
-    // The current score
     // internal
     private val _score = MutableLiveData<Int>()
     //external

--- a/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
+++ b/app/src/main/java/com/anelcc/guessexample/screen/game/GameViewModel.kt
@@ -26,7 +26,7 @@ class GameViewModel : ViewModel(){
     init {
         resetList()
         nextWord()
-        score.value = 0
+        _score.value = 0
         Log.i("GameViewModel", "GameViewModel created")
     }
 
@@ -81,12 +81,12 @@ class GameViewModel : ViewModel(){
 
     fun onSkip() {
         //no safe
-        score.value = (score.value)?.minus(1)
+        _score.value = (score.value)?.minus(1)
         nextWord()
     }
 
     fun onCorrect() {
-        score.value = (score.value)?.plus(1)
+        _score.value = (score.value)?.plus(1)
         nextWord()
     }
 }


### PR DESCRIPTION
Make internal and external versions of word and score:
```
// internal
private val _score = MutableLiveData<Int>()
//external
val score: LiveData<Int>
```

Make a backing property for the external version that returns the internal MutableLiveData as a LiveData:
Kotlin automatically makes getters and setters for your fields. I have a example using getters [here](https://github.com/AnelCC/Kotlin-Oreilly/pull/4) 

If you want to override the getter for score, you can do so using a backing property. You've actually already defined your backing properties (_score and _word). Now you can take your public versions of the variables (score and word) and override get to return the backing properties.

For example, here’s the full encapsulated score:
```
private val _score = MutableLiveData<Int>()
val score: LiveData<Int>
    get() = _score
```

